### PR TITLE
Issue #26 Switch-to-projects/packages: support for packages built from multiple projects

### DIFF
--- a/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
+++ b/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
@@ -14,7 +14,8 @@ namespace Dnt.Commands.Packages.Switcher
         public string Solution { get; set; }
 
         [JsonProperty("mappings")]
-        public Dictionary<string, string> Mappings { get; } = new Dictionary<string, string>();
+        [JsonConverter(typeof(SingleOrArrayConverter))]
+        public Dictionary<string, List<string>> Mappings { get; set; }
 
         [JsonProperty("restore", NullValueHandling = NullValueHandling.Ignore)]
         public List<RestoreProjectInformation> Restore { get; set; } = new List<RestoreProjectInformation>();
@@ -30,7 +31,7 @@ namespace Dnt.Commands.Packages.Switcher
         public static ReferenceSwitcherConfiguration Load(string filePath)
         {
             var c = JsonConvert.DeserializeObject<ReferenceSwitcherConfiguration>(File.ReadAllText(filePath));
-            c.Path = PathUtilities.ToAbsolutePath(filePath, Directory.GetCurrentDirectory()); ; ;
+            c.Path = PathUtilities.ToAbsolutePath(filePath, Directory.GetCurrentDirectory());
             return c;
         }
 

--- a/src/Dnt.Commands/Packages/Switcher/SingleOrArrayConvertor.cs
+++ b/src/Dnt.Commands/Packages/Switcher/SingleOrArrayConvertor.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Dnt.Commands.Packages.Switcher
+{
+    class SingleOrArrayConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Dictionary<string, List<string>>) ||
+                   objectType == typeof(Dictionary<string, string>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            var result = new Dictionary<string, List<string>>();
+
+            switch (token.First.First.Type)
+            {
+                case JTokenType.String:
+                    return token.Children<JProperty>().ToDictionary(val => val.Name, val => new List<string> { val.First.Value<string>() });
+                case JTokenType.Array:
+                    return token.ToObject<Dictionary<string, List<string>>>();
+                default:
+                    throw new InvalidCastException();
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var result = new JObject();
+            var properties = value as Dictionary<string, List<string>>;
+
+            foreach (var property in properties)
+            {
+                if (property.Value.Count > 1)
+                {
+                    result.Add(new JProperty(property.Key, property.Value));
+                }
+                else
+                {
+                    result.Add(new JProperty(property.Key, property.Value.First()));
+                }
+            }
+
+            writer.WriteToken(result.CreateReader());
+        }
+    }
+}


### PR DESCRIPTION
This commit implements the custom JSON convertor and updates the corresponding functions to support a list of project paths instead of a single path. This fixes issue #26 for switching between projects and packages.

I have tested switching between projects and packages with my own solution that includes the nuget package "OPCFoundation.NetStandard.Opc.Ua" built from [UA-.NETStandard](https://github.com/OPCFoundation/UA-.NETStandard) and with the Nswag project. This all seems to be working fine.

