### PR TITLE
Restore original project file line endings after Microsoft.Build has overwritten them

### DIFF
--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -126,7 +126,7 @@ namespace Dnt.Commands.Packages
                 }
             }
 
-            project.Save();
+            ProjectExtensions.SaveWithLineEndings(projectInformation);
 
             return switchedProjects;
         }

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -148,7 +148,7 @@ namespace Dnt.Commands.Packages
 
                     if (count > 0)
                     {
-                        project.Save();
+                        ProjectExtensions.SaveWithLineEndings(projectInformation);
                     }
                 }
             }

--- a/src/Dnt.Commands/ProjectExtensions.cs
+++ b/src/Dnt.Commands/ProjectExtensions.cs
@@ -50,12 +50,15 @@ namespace Dnt.Commands
                 }
             }
 
+            var projectFileContent = File.ReadAllText(projectPath);
+            var lineEndings = projectFileContent.Contains("\r\n") ? "\r\n" : "\n";
+
             try
             {
                 var projectCollection = new ProjectCollection(globalProperties);
                 var project = projectCollection.LoadProject(projectPath);
 
-                return new ProjectInformation(projectCollection, project, !isSdkStyle);
+                return new ProjectInformation(projectCollection, project, !isSdkStyle, lineEndings);
             }
             catch (InvalidProjectFileException projectFileException)
             {
@@ -72,6 +75,16 @@ namespace Dnt.Commands
             {
                 { "SolutionDir", solutionDir }
             };
+        }
+
+        public static void SaveWithLineEndings(ProjectInformation projectInformation)
+        {
+            projectInformation.Project.Save();
+            if (projectInformation.LineEndings != Environment.NewLine)
+            {
+                var path = projectInformation.Project.FullPath;
+                File.WriteAllText(path, File.ReadAllText(path).Replace(Environment.NewLine, projectInformation.LineEndings));
+            }
         }
     }
 }

--- a/src/Dnt.Commands/ProjectInformation.cs
+++ b/src/Dnt.Commands/ProjectInformation.cs
@@ -7,16 +7,19 @@ namespace Dnt.Commands
     {
         private readonly ProjectCollection _projectCollection;
 
-        public ProjectInformation(ProjectCollection projectCollection, Project project, bool isLegacyProject)
+        public ProjectInformation(ProjectCollection projectCollection, Project project, bool isLegacyProject, string lineEndings)
         {
             _projectCollection = projectCollection;
             Project = project;
             IsLegacyProject = isLegacyProject;
+            LineEndings = lineEndings;
         }
 
         public Project Project { get; }
 
         public bool IsLegacyProject { get; }
+
+        public string LineEndings { get; }
 
         public bool IsSdkProject => !IsLegacyProject;
 

--- a/src/Dnt.Commands/Projects/AddTargetFrameworkCommand.cs
+++ b/src/Dnt.Commands/Projects/AddTargetFrameworkCommand.cs
@@ -86,7 +86,7 @@ namespace Dnt.Commands.Projects
                                 System.IO.Path.GetFileName(projectPath) + "\n");
                         }
 
-                        project.Save();
+                        ProjectExtensions.SaveWithLineEndings(projectInformation);
                     }
                 }
                 catch (Exception e)

--- a/src/Dnt.Commands/Projects/BumpVersionsCommand.cs
+++ b/src/Dnt.Commands/Projects/BumpVersionsCommand.cs
@@ -37,7 +37,7 @@ namespace Dnt.Commands.Projects
 
                             if (!Simulate)
                             {
-                                projectInformation.Project.Save();
+                                ProjectExtensions.SaveWithLineEndings(projectInformation);
                             }
                         }
                         else

--- a/src/Dnt.Commands/Projects/ChangeVersionsCommand.cs
+++ b/src/Dnt.Commands/Projects/ChangeVersionsCommand.cs
@@ -55,7 +55,7 @@ namespace Dnt.Commands.Projects
 
                                 if (!Simulate)
                                 {
-                                    projectInformation.Project.Save();
+                                    ProjectExtensions.SaveWithLineEndings(projectInformation);
                                 }
                             }
                             else

--- a/src/Dnt.Commands/Projects/EnableCommand.cs
+++ b/src/Dnt.Commands/Projects/EnableCommand.cs
@@ -43,7 +43,7 @@ namespace Dnt.Commands.Projects
 
                             if (!Simulate)
                             {
-                                project.Save();
+                                ProjectExtensions.SaveWithLineEndings(projectInformation);
                             }
                         }
                         else

--- a/src/Dnt.Commands/Projects/NoWarnCommand.cs
+++ b/src/Dnt.Commands/Projects/NoWarnCommand.cs
@@ -42,7 +42,7 @@ namespace Dnt.Commands.Projects
                             }
                         }
 
-                        project.Save();
+                        ProjectExtensions.SaveWithLineEndings(projectInformation);
                     }
                 }
                 catch (Exception e)

--- a/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
@@ -55,7 +55,7 @@ namespace Dnt.Commands.Projects
                             projectInformation.Project.AddItem("ProjectReference", path, metaData);
                         }
 
-                        projectInformation.Project.Save();
+                        ProjectExtensions.SaveWithLineEndings(projectInformation);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
Fixes #98.

@RicoSuter: I don't know if this is too invasive?

It first reads the full project file into memory and looks for a single `CRLF` to determine the line endings. This could be changed to use a reader and only read until the first newline. Alternatively, the logic could be changed to count and compare number of carriage returns and newlines (for example checking if `CR > LF / 2`) to better handle mixed line endings.

Then it reads the whole file into memory again at the end to replace the line breaks, if they differ from the line endings used by Microsoft.Build. I don't think this can be done in a streaming fashion without using a temporary file, but that may be preferable.

I haven't been able to find a way to override the behavior of `Microsoft.Build.Evaluation.Project.Save`.