### PR TITLE
Preserve solution folder placement across reference switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,23 @@
-# DNT (DotNetTools) — fork
+# DNT (DotNetTools)
+## Command line tools to manage .NET Core, Standard and SDK-style projects and solutions
 
-This repository is a maintained fork of the original DNT CLI with a focus on day‑to‑day solution maintenance. The fork keeps the same command surface but updates the internals to better handle **solution folders** and modern SDK-style layouts.
+[![NuGet Version](https://img.shields.io/nuget/v/DNT.svg)](https://www.nuget.org/packages/DNT)
+[![npm](https://img.shields.io/npm/v/dotnettools.svg)](https://www.npmjs.com/package/dotnettools)
 
-## Why this fork exists
-
-The upstream tool did not fully support solution folders, which made some commands skip projects or resolve paths incorrectly. This fork updates the solution parsing so commands work as expected in solutions that organize projects into folders.
-
-## What you can do with DNT
-
-DNT is a CLI toolbox for batch operations across .NET projects and solutions:
-
-- Manage NuGet packages (install, update, list).
-- Bump or set package versions across many projects.
-- Toggle features like `TreatWarningsAsErrors` and XML docs.
-- Switch between NuGet references and project references.
-- Analyze used packages and licenses.
+**Command and parameter names may improve or change over time. Please create issues or PRs if you'd like to fix, change or add a command.**
 
 ## Installation
 
-### .NET global tool (recommended)
+### .NET Core global tool
+#### Requires .NET 8.0+ and Visual Studio 2019
+
+Install .NET Core global tool:
 
 ```
 dotnet tool install -g dnt
 ```
 
-Update the tool:
+Update the global tool:
 
 ```
 dotnet tool update -g dnt
@@ -36,21 +29,26 @@ Uninstall the tool:
 dotnet tool uninstall -g dnt
 ```
 
-### NPM package
+### NPM CLI package
+#### Requires .NET Core 2.2+ or NetFX 4.7.2 and Visual Studio 2019
+
+Globally install/update via NPM (.NET 4.6.2+ and .NET Core 2.1+):
 
 ```
 npm i -g dotnettools
 ```
 
-Uninstall:
+Uninstall global package:
 
 ```
 npm uninstall -g dotnettools
 ```
 
-## Usage basics
+## Usage
 
-By default, commands operate on all `*.csproj` files found under the current directory. You can narrow the scope to a specific project directory or solution:
+By default, all commands search in the current directory for all `*.csproj` files and apply the command to all of them. The targeted projects or solutions can be changed with the `/path:MyProject.csproj` parameter.
+
+To list all currently selected projects, call:
 
 ```
 dnt list-projects
@@ -58,52 +56,331 @@ dnt list-projects
 dnt list-projects /path:MySolution.sln
 ```
 
-### Common commands
+Available commands:
+
+- [Package Commands](#package-commands)
+- [Project Commands](#project-commands)
+- [Solution Commands](#solution-commands)
+
+Possible scenarios to use the tools: 
+
+- [Azure DevOps: A way to version and publish .NET packages from a GitHub repository](https://blog.rsuter.com/azure-devops-my-versioning-flow-to-publish-dotnet-packages-from-github-repository/)
+
+## Package Commands
+
+### install-packages
+
+Installs a NuGet package in the selected projects.
+
+**Command:**
 
 ```
-# Packages
+dnt install-packages PackageToInstall [TargetPackageVersion] [/path:ProjectDirectoryPath]
+```
 
-dnt install-packages PackageId [Version] [/path:ProjectOrSolution]
+**Parameters:**
 
-dnt update-packages PackageId [Version] [/path:ProjectOrSolution]
+- PackageToInstall
+- TargetPackageVersion
+- ProjectDirectoryPath
 
-# Versions
+### update-packages
 
+Updates NuGet packages in the selected projects.
+
+**Command:**
+
+```
+dnt update-packages PackagesToUpdate [TargetPackageVersion] [/path:ProjectDirectoryPath]
+```
+
+**Parameters:**
+
+- PackagesToUpdate: The package ID to update, also supports * wildcards
+- TargetPacketVersion: The targeted package version (default: latest)
+- ProjectDirectoryPath
+
+**Samples:**
+
+Update all packages in the selected projects to the latest version:
+
+```
+dnt update-packages *
+```
+
+Update the `Newtonsoft.Json` packages in the selected projects to version `10.0.1`:
+
+```
+dnt update-packages Newtonsoft.Json 10.0.1
+```
+
+Update all packages which start with `MyPackages.` to version `2.1.0` in the selected projects:
+
+```
+dnt update-packages MyPackages.* 2.1.0
+```
+
+### bump-versions
+
+Increases or changes the package version of the selected projects.
+
+**Command:**
+
+```
 dnt bump-versions major|minor|patch|revision [number]
+```
 
-dnt change-versions 1.2.3 [replace|force]
+**Parameters:**
 
-# Project settings
+- Action: Specifies the version segment to bump (major|minor|patch|revision) by 1 or by the specified number
+- Number: The version to bump up to (if not specified: Increase by 1)
 
-dnt enable warnaserror|xmldocs
+**Samples:**
 
-dnt nowarn CS1591
+Bump the minor version of all selected projects by 1:
 
-dnt add-target-framework netstandard2.0
+```
+dnt bump-versions minor
+```
 
-# Solution/project switching
+Set the patch version of all selected projects to 18:
 
+```
+dnt bump-versions patch 18
+```
+
+### switch-to-projects
+
+This command switches NuGet assembly references to project references and vice-versa. This is useful when developing applications/libraries which reference own NuGet packages: When developing an application, switch to project references so that all code is editable and debuggable. After finishing the development, create new NuGet package versions, switch back to NuGet references and upgrade to the new NuGet versions.
+
+This command supports .csproj, .vbproj, legacy and SDK-style projects (.NET Core/Standard). Previously it was implemented as a Visual Studio extension: [NuGetReferenceSwitcher](https://github.com/RSuter/NuGetReferenceSwitcher).
+
+#### Usage
+
+Create a `switcher.json` file and specify the solution to look for projects, and the NuGet packages to replace with actual projects. The involved projects are only specified by the solution path in the settings file.
+
+The command supports switching to project references where the NuGet package is built from a single project or when it is built from multiple projects, i.e. the package contains multiple libraries.
+
+**Sample - single project per package:** Here we create a switcher file for [NSwag](http://nswag.org) which references libraries of [NJsonSchema](http://njsonschema.org) to work on both projects in a single solution: 
+
+```json
+{
+  "solution": "NSwag.sln",
+  "mappings": {
+    "NJsonSchema": "../../NJsonSchema/src/NJsonSchema/NJsonSchema.csproj",
+    "NJsonSchema.CodeGeneration": "../../NJsonSchema/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj",
+    "NJsonSchema.CodeGeneration.CSharp": "../../NJsonSchema/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj",
+    "NJsonSchema.CodeGeneration.TypeScript": "../../NJsonSchema/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj"
+  }
+}
+```
+
+**Sample - multiple projects per package:** Here we create a switcher file for a sample solution which references multiple libraries included (as dependencies) in the [UA-.NETStandard](https://github.com/OPCFoundation/UA-.NETStandard) [OPCFoundation.NetStandard.Opc.Ua](https://www.nuget.org/packages/OPCFoundation.NetStandard.Opc.Ua/) package in order to work on all the projects in a single solution.
+
+```json
+{
+  "solution": "MyOpcUaApp.sln",
+  "mappings": {
+    "OPCFoundation.NetStandard.Opc.Ua": [
+      "../UA-.NETStandard/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj",
+      "../UA-.NETStandard/Stack/Opc.Ua.Bindings.Https/Opc.Ua.Bindings.Https.csproj",
+      "../UA-.NETStandard/Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj",
+      "../UA-.NETStandard/Libraries/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj",
+      "../UA-.NETStandard/Libraries/Opc.Ua.Client/Opc.Ua.Client.csproj",
+      "../UA-.NETStandard/Libraries/Opc.Ua.Server/Opc.Ua.Server.csproj",
+      "../UA-.NETStandard/Libraries/Opc.Ua.Gds.Client.Common/Opc.Ua.Gds.Client.Common.csproj",
+      "../UA-.NETStandard/Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj",
+    ]
+  }
+}
+```
+
+Then switch to projects in the solution: 
+
+```
 dnt switch-to-projects
+```
 
+The command looks for `switcher.json` configuration file by default, but you can specify your own file:
+
+```
+dnt switch-to-projects switch-config.json
+```
+
+Now all NJsonSchema, or UA-.NETStandard, package references in the NSwag, or MyOpcUaApp, solution are replaced by local project references and the NJsonSchema, or UA-.NETStandard, projects are added to the solution.
+
+**Optional `switcher.json` Flags:**
+
+- removeProjects: (Default: true) Removes mapped projects from the solution and ignores mapped projects when using switch-to-packages.
+
+### switch-to-packages
+
+After implementing and testing, switch back to NuGet references and update to the latest version: 
+
+```
 dnt switch-to-packages
+dnt update-packages NJsonSchema*
+# or
+dnt update-packages OPCFoundation.NetStandard.Opc.Ua.*
 ```
 
-## Solution folder support
+### used-packages
 
-When you target a solution (`/path:MySolution.sln`), this fork will traverse all projects even if they are organized inside solution folders. If you were previously seeing missing projects, re-run with the same command and it should now pick them up correctly.
+Lists all used packages, transitive packages in the projects and their licenses.
 
-## Use this fork with an existing DNT installation
+**Parameters:**
 
-If you are using the official DNT tool but want the solution-folder fixes from this fork, you can compile this repository and replace the command assembly in your local tool cache. On Windows, copy `Dnt.Commands.dll` and `Dnt.Commands.pdb` into:
+- ExcludeMicrosoft (default: true): Exclude packages which start with Microsoft.*
+- ExcludeSystem (default: true): Exclude packages which start with System.*
+- IncludeTransitiveDependencies (default: true): Also analyze transitive dependencies (i.e. indirectly referenced packages)
+
+Sample output for [NJsonSchema](http://njsonschema.org):
 
 ```
-C:\Users\{{userName}}\.dotnet\tools\.store\dnt\3.0.0\dnt\3.0.0\tools\net10.0\any
+Package                              Version   #   License   License URL
+BenchmarkDotNet                      0.10.14   1   MIT       https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md
+BenchmarkDotNet.Core                 0.10.14   4   MIT       https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md
+BenchmarkDotNet.Toolchains.Roslyn    0.10.14   1   MIT       https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md
+DotLiquid                            2.0.254   1   Apache    http://www.apache.org/licenses/LICENSE-2.0
+NBench                               1.0.4     2   Apache    https://github.com/petabridge/NBench/blob/master/LICENSE
+Newtonsoft.Json                      9.0.1     4   MIT       https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md
+NodaTime                             2.2.0     2   Apache    http://www.apache.org/licenses/LICENSE-2.0
+Pro.NBench.xUnit                     1.0.4     1   MIT       https://raw.githubusercontent.com/Pro-Coded/Pro.NBench.xUnit/master/LICENSE
+xunit                                2.3.1     7   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+xunit.abstractions                   2.0.1     2   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+xunit.analyzers                      0.7.0     1   Apache    https://raw.githubusercontent.com/xunit/xunit.analyzers/master/LICENSE
+xunit.assert                         2.3.1     1   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+xunit.core                           2.3.1     1   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+xunit.extensibility.core             2.3.1     3   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+xunit.extensibility.execution        2.3.1     1   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+xunit.runner.visualstudio            2.3.1     6   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
+YamlDotNet.Signed                    5.0.1     1   MIT       https://github.com/aaubry/YamlDotNet/blob/master/LICENSE
 ```
 
-## Contributing
+### switch-assemblies-to-projects
 
-Issues and PRs are welcome. If you report a bug, include the exact command, your `.sln` layout, and the output you received so we can reproduce it quickly.
+Looks through all the projects for assembly/DLL references that could instead be project references in the same solution. 
 
-## License
+The command does make the assumption that the assembly output of a project has the same name as the project.
 
-See [LICENSE.md](LICENSE.md).
+```
+dnt switch-assemblies-to-projects
+```
+
+Looks for references like
+
+```
+<Reference Include="ProjectA">
+  <HintPath>..\ProjectA\bin\ProjectA.dll</HintPath>
+</Reference>
+```
+
+And replaces with
+
+```
+<ProjectReference Include="..\ProjectA\ProjectA.csproj">
+  <Project>{B12406B0-0468-4809-91E3-7991800E3ECD}</Project>
+  <Name>ProjectA</Name>
+</ProjectReference>
+```
+
+## Project Commands
+
+### enable
+
+Enables a project feature in all selected projects.
+
+**Command:**
+
+```
+dnt enable warnaserror|xmldocs
+```
+
+**Parameters:**
+
+- Action: Specifies the feature to enable (warnaserror|xmldocs)
+
+**Samples:**
+
+Handle all warnings as errors in all selected projects: 
+
+```
+dnt enable warnaserror
+```
+
+### nowarn
+
+Adds a diagnostic id to the `<NoWarn>` tag (supports muliple ids, semicolon separated).
+
+**Samples:**
+
+Disable "Missing XML comment for publicly visible type or member" warnings in all selected projects:
+
+```
+dnt nowarn CS1591
+```
+
+### add-target-framework
+
+Add another target framework to the selected projects.
+
+**Command:**
+
+```
+dnt add-target-framework TargetFramework
+```
+
+**Parameters:**
+
+- TargetFramework: Specifies the target framework to add
+
+**Samples:**
+
+Add .NET Standard 2.0 target framework to all projects:
+
+```
+dnt add-target-framework netstandard2.0
+```
+
+### clean
+
+Deletes all /bin and /obj directories of the selected projects.
+
+### change-versions
+
+Replaces or sets the package version of the selected projects.  Projects must have the GeneratePackageOnBuild flag set.
+
+**Command:**
+
+```
+dnt change-versions version [replace|force]
+```
+
+**Parameters:**
+
+- Version: The full version number using the format 'major.minor[.patch][.revision]'. Version will be padded to three parts.
+- Action: Action to perform (replace|force). replace (default) = Only set for projects with an existing version, force = Set for all projects even if version is missing or blank
+
+**Samples:**
+
+Replace projects with an existing version tag with 1.0.1:
+
+```
+dnt change-versions 1.0.1
+```
+
+Force set all projects to 1.2.0
+
+```
+dnt change-versions 1.2 force
+```
+
+Replace version with a long version:
+
+```
+dnt change-versions 1.2.3.4-PreRelease1 replace
+```
+
+# DNT development and testing
+
+It is recommended to add the debug output path "DNT/src/Dnt.NetFx/bin/Debug" to the Path environment variable, or directly start the app with a command.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,30 @@
-# DNT (DotNetTools)
-## Command line tools to manage .NET Core, Standard and SDK-style projects and solutions
+# DNT (DotNetTools) — fork
 
-[![NuGet Version](https://img.shields.io/nuget/v/DNT.svg)](https://www.nuget.org/packages/DNT)
-[![npm](https://img.shields.io/npm/v/dotnettools.svg)](https://www.npmjs.com/package/dotnettools)
+This repository is a maintained fork of the original DNT CLI with a focus on day‑to‑day solution maintenance. The fork keeps the same command surface but updates the internals to better handle **solution folders** and modern SDK-style layouts.
 
-**Command and parameter names may improve or change over time. Please create issues or PRs if you'd like to fix, change or add a command.**
+## Why this fork exists
+
+The upstream tool did not fully support solution folders, which made some commands skip projects or resolve paths incorrectly. This fork updates the solution parsing so commands work as expected in solutions that organize projects into folders.
+
+## What you can do with DNT
+
+DNT is a CLI toolbox for batch operations across .NET projects and solutions:
+
+- Manage NuGet packages (install, update, list).
+- Bump or set package versions across many projects.
+- Toggle features like `TreatWarningsAsErrors` and XML docs.
+- Switch between NuGet references and project references.
+- Analyze used packages and licenses.
 
 ## Installation
 
-### .NET Core global tool
-#### Requires .NET 8.0+ and Visual Studio 2019
-
-Install .NET Core global tool:
+### .NET global tool (recommended)
 
 ```
 dotnet tool install -g dnt
 ```
 
-Update the global tool:
+Update the tool:
 
 ```
 dotnet tool update -g dnt
@@ -29,26 +36,21 @@ Uninstall the tool:
 dotnet tool uninstall -g dnt
 ```
 
-### NPM CLI package
-#### Requires .NET Core 2.2+ or NetFX 4.7.2 and Visual Studio 2019
-
-Globally install/update via NPM (.NET 4.6.2+ and .NET Core 2.1+):
+### NPM package
 
 ```
 npm i -g dotnettools
 ```
 
-Uninstall global package:
+Uninstall:
 
 ```
 npm uninstall -g dotnettools
 ```
 
-## Usage
+## Usage basics
 
-By default, all commands search in the current directory for all `*.csproj` files and apply the command to all of them. The targeted projects or solutions can be changed with the `/path:MyProject.csproj` parameter.
-
-To list all currently selected projects, call:
+By default, commands operate on all `*.csproj` files found under the current directory. You can narrow the scope to a specific project directory or solution:
 
 ```
 dnt list-projects
@@ -56,331 +58,52 @@ dnt list-projects
 dnt list-projects /path:MySolution.sln
 ```
 
-Available commands:
-
-- [Package Commands](#package-commands)
-- [Project Commands](#project-commands)
-- [Solution Commands](#solution-commands)
-
-Possible scenarios to use the tools: 
-
-- [Azure DevOps: A way to version and publish .NET packages from a GitHub repository](https://blog.rsuter.com/azure-devops-my-versioning-flow-to-publish-dotnet-packages-from-github-repository/)
-
-## Package Commands
-
-### install-packages
-
-Installs a NuGet package in the selected projects.
-
-**Command:**
+### Common commands
 
 ```
-dnt install-packages PackageToInstall [TargetPackageVersion] [/path:ProjectDirectoryPath]
-```
+# Packages
 
-**Parameters:**
+dnt install-packages PackageId [Version] [/path:ProjectOrSolution]
 
-- PackageToInstall
-- TargetPackageVersion
-- ProjectDirectoryPath
+dnt update-packages PackageId [Version] [/path:ProjectOrSolution]
 
-### update-packages
+# Versions
 
-Updates NuGet packages in the selected projects.
-
-**Command:**
-
-```
-dnt update-packages PackagesToUpdate [TargetPackageVersion] [/path:ProjectDirectoryPath]
-```
-
-**Parameters:**
-
-- PackagesToUpdate: The package ID to update, also supports * wildcards
-- TargetPacketVersion: The targeted package version (default: latest)
-- ProjectDirectoryPath
-
-**Samples:**
-
-Update all packages in the selected projects to the latest version:
-
-```
-dnt update-packages *
-```
-
-Update the `Newtonsoft.Json` packages in the selected projects to version `10.0.1`:
-
-```
-dnt update-packages Newtonsoft.Json 10.0.1
-```
-
-Update all packages which start with `MyPackages.` to version `2.1.0` in the selected projects:
-
-```
-dnt update-packages MyPackages.* 2.1.0
-```
-
-### bump-versions
-
-Increases or changes the package version of the selected projects.
-
-**Command:**
-
-```
 dnt bump-versions major|minor|patch|revision [number]
-```
 
-**Parameters:**
+dnt change-versions 1.2.3 [replace|force]
 
-- Action: Specifies the version segment to bump (major|minor|patch|revision) by 1 or by the specified number
-- Number: The version to bump up to (if not specified: Increase by 1)
+# Project settings
 
-**Samples:**
-
-Bump the minor version of all selected projects by 1:
-
-```
-dnt bump-versions minor
-```
-
-Set the patch version of all selected projects to 18:
-
-```
-dnt bump-versions patch 18
-```
-
-### switch-to-projects
-
-This command switches NuGet assembly references to project references and vice-versa. This is useful when developing applications/libraries which reference own NuGet packages: When developing an application, switch to project references so that all code is editable and debuggable. After finishing the development, create new NuGet package versions, switch back to NuGet references and upgrade to the new NuGet versions.
-
-This command supports .csproj, .vbproj, legacy and SDK-style projects (.NET Core/Standard). Previously it was implemented as a Visual Studio extension: [NuGetReferenceSwitcher](https://github.com/RSuter/NuGetReferenceSwitcher).
-
-#### Usage
-
-Create a `switcher.json` file and specify the solution to look for projects, and the NuGet packages to replace with actual projects. The involved projects are only specified by the solution path in the settings file.
-
-The command supports switching to project references where the NuGet package is built from a single project or when it is built from multiple projects, i.e. the package contains multiple libraries.
-
-**Sample - single project per package:** Here we create a switcher file for [NSwag](http://nswag.org) which references libraries of [NJsonSchema](http://njsonschema.org) to work on both projects in a single solution: 
-
-```json
-{
-  "solution": "NSwag.sln",
-  "mappings": {
-    "NJsonSchema": "../../NJsonSchema/src/NJsonSchema/NJsonSchema.csproj",
-    "NJsonSchema.CodeGeneration": "../../NJsonSchema/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj",
-    "NJsonSchema.CodeGeneration.CSharp": "../../NJsonSchema/src/NJsonSchema.CodeGeneration.CSharp/NJsonSchema.CodeGeneration.CSharp.csproj",
-    "NJsonSchema.CodeGeneration.TypeScript": "../../NJsonSchema/src/NJsonSchema.CodeGeneration.TypeScript/NJsonSchema.CodeGeneration.TypeScript.csproj"
-  }
-}
-```
-
-**Sample - multiple projects per package:** Here we create a switcher file for a sample solution which references multiple libraries included (as dependencies) in the [UA-.NETStandard](https://github.com/OPCFoundation/UA-.NETStandard) [OPCFoundation.NetStandard.Opc.Ua](https://www.nuget.org/packages/OPCFoundation.NetStandard.Opc.Ua/) package in order to work on all the projects in a single solution.
-
-```json
-{
-  "solution": "MyOpcUaApp.sln",
-  "mappings": {
-    "OPCFoundation.NetStandard.Opc.Ua": [
-      "../UA-.NETStandard/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj",
-      "../UA-.NETStandard/Stack/Opc.Ua.Bindings.Https/Opc.Ua.Bindings.Https.csproj",
-      "../UA-.NETStandard/Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj",
-      "../UA-.NETStandard/Libraries/Opc.Ua.Configuration/Opc.Ua.Configuration.csproj",
-      "../UA-.NETStandard/Libraries/Opc.Ua.Client/Opc.Ua.Client.csproj",
-      "../UA-.NETStandard/Libraries/Opc.Ua.Server/Opc.Ua.Server.csproj",
-      "../UA-.NETStandard/Libraries/Opc.Ua.Gds.Client.Common/Opc.Ua.Gds.Client.Common.csproj",
-      "../UA-.NETStandard/Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj",
-    ]
-  }
-}
-```
-
-Then switch to projects in the solution: 
-
-```
-dnt switch-to-projects
-```
-
-The command looks for `switcher.json` configuration file by default, but you can specify your own file:
-
-```
-dnt switch-to-projects switch-config.json
-```
-
-Now all NJsonSchema, or UA-.NETStandard, package references in the NSwag, or MyOpcUaApp, solution are replaced by local project references and the NJsonSchema, or UA-.NETStandard, projects are added to the solution.
-
-**Optional `switcher.json` Flags:**
-
-- removeProjects: (Default: true) Removes mapped projects from the solution and ignores mapped projects when using switch-to-packages.
-
-### switch-to-packages
-
-After implementing and testing, switch back to NuGet references and update to the latest version: 
-
-```
-dnt switch-to-packages
-dnt update-packages NJsonSchema*
-# or
-dnt update-packages OPCFoundation.NetStandard.Opc.Ua.*
-```
-
-### used-packages
-
-Lists all used packages, transitive packages in the projects and their licenses.
-
-**Parameters:**
-
-- ExcludeMicrosoft (default: true): Exclude packages which start with Microsoft.*
-- ExcludeSystem (default: true): Exclude packages which start with System.*
-- IncludeTransitiveDependencies (default: true): Also analyze transitive dependencies (i.e. indirectly referenced packages)
-
-Sample output for [NJsonSchema](http://njsonschema.org):
-
-```
-Package                              Version   #   License   License URL
-BenchmarkDotNet                      0.10.14   1   MIT       https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md
-BenchmarkDotNet.Core                 0.10.14   4   MIT       https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md
-BenchmarkDotNet.Toolchains.Roslyn    0.10.14   1   MIT       https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md
-DotLiquid                            2.0.254   1   Apache    http://www.apache.org/licenses/LICENSE-2.0
-NBench                               1.0.4     2   Apache    https://github.com/petabridge/NBench/blob/master/LICENSE
-Newtonsoft.Json                      9.0.1     4   MIT       https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md
-NodaTime                             2.2.0     2   Apache    http://www.apache.org/licenses/LICENSE-2.0
-Pro.NBench.xUnit                     1.0.4     1   MIT       https://raw.githubusercontent.com/Pro-Coded/Pro.NBench.xUnit/master/LICENSE
-xunit                                2.3.1     7   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-xunit.abstractions                   2.0.1     2   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-xunit.analyzers                      0.7.0     1   Apache    https://raw.githubusercontent.com/xunit/xunit.analyzers/master/LICENSE
-xunit.assert                         2.3.1     1   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-xunit.core                           2.3.1     1   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-xunit.extensibility.core             2.3.1     3   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-xunit.extensibility.execution        2.3.1     1   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-xunit.runner.visualstudio            2.3.1     6   Apache    https://raw.githubusercontent.com/xunit/xunit/master/license.txt
-YamlDotNet.Signed                    5.0.1     1   MIT       https://github.com/aaubry/YamlDotNet/blob/master/LICENSE
-```
-
-### switch-assemblies-to-projects
-
-Looks through all the projects for assembly/DLL references that could instead be project references in the same solution. 
-
-The command does make the assumption that the assembly output of a project has the same name as the project.
-
-```
-dnt switch-assemblies-to-projects
-```
-
-Looks for references like
-
-```
-<Reference Include="ProjectA">
-  <HintPath>..\ProjectA\bin\ProjectA.dll</HintPath>
-</Reference>
-```
-
-And replaces with
-
-```
-<ProjectReference Include="..\ProjectA\ProjectA.csproj">
-  <Project>{B12406B0-0468-4809-91E3-7991800E3ECD}</Project>
-  <Name>ProjectA</Name>
-</ProjectReference>
-```
-
-## Project Commands
-
-### enable
-
-Enables a project feature in all selected projects.
-
-**Command:**
-
-```
 dnt enable warnaserror|xmldocs
-```
 
-**Parameters:**
-
-- Action: Specifies the feature to enable (warnaserror|xmldocs)
-
-**Samples:**
-
-Handle all warnings as errors in all selected projects: 
-
-```
-dnt enable warnaserror
-```
-
-### nowarn
-
-Adds a diagnostic id to the `<NoWarn>` tag (supports muliple ids, semicolon separated).
-
-**Samples:**
-
-Disable "Missing XML comment for publicly visible type or member" warnings in all selected projects:
-
-```
 dnt nowarn CS1591
-```
 
-### add-target-framework
-
-Add another target framework to the selected projects.
-
-**Command:**
-
-```
-dnt add-target-framework TargetFramework
-```
-
-**Parameters:**
-
-- TargetFramework: Specifies the target framework to add
-
-**Samples:**
-
-Add .NET Standard 2.0 target framework to all projects:
-
-```
 dnt add-target-framework netstandard2.0
+
+# Solution/project switching
+
+dnt switch-to-projects
+
+dnt switch-to-packages
 ```
 
-### clean
+## Solution folder support
 
-Deletes all /bin and /obj directories of the selected projects.
+When you target a solution (`/path:MySolution.sln`), this fork will traverse all projects even if they are organized inside solution folders. If you were previously seeing missing projects, re-run with the same command and it should now pick them up correctly.
 
-### change-versions
+## Use this fork with an existing DNT installation
 
-Replaces or sets the package version of the selected projects.  Projects must have the GeneratePackageOnBuild flag set.
-
-**Command:**
+If you are using the official DNT tool but want the solution-folder fixes from this fork, you can compile this repository and replace the command assembly in your local tool cache. On Windows, copy `Dnt.Commands.dll` and `Dnt.Commands.pdb` into:
 
 ```
-dnt change-versions version [replace|force]
+C:\Users\{{userName}}\.dotnet\tools\.store\dnt\3.0.0\dnt\3.0.0\tools\net10.0\any
 ```
 
-**Parameters:**
+## Contributing
 
-- Version: The full version number using the format 'major.minor[.patch][.revision]'. Version will be padded to three parts.
-- Action: Action to perform (replace|force). replace (default) = Only set for projects with an existing version, force = Set for all projects even if version is missing or blank
+Issues and PRs are welcome. If you report a bug, include the exact command, your `.sln` layout, and the output you received so we can reproduce it quickly.
 
-**Samples:**
+## License
 
-Replace projects with an existing version tag with 1.0.1:
-
-```
-dnt change-versions 1.0.1
-```
-
-Force set all projects to 1.2.0
-
-```
-dnt change-versions 1.2 force
-```
-
-Replace version with a long version:
-
-```
-dnt change-versions 1.2.3.4-PreRelease1 replace
-```
-
-# DNT development and testing
-
-It is recommended to add the debug output path "DNT/src/Dnt.NetFx/bin/Debug" to the Path environment variable, or directly start the app with a command.
+See [LICENSE.md](LICENSE.md).

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -6,16 +6,29 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dnt.Commands.Infrastructure;
 using Dnt.Commands.Packages.Switcher;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 using NConsole;
 using Microsoft.VisualStudio.SolutionPersistence.Model;
+using System.Xml.Linq;
+using System.Text.RegularExpressions;
 
 namespace Dnt.Commands.Packages
 {
     [Command(Name = "switch-to-packages", Description = "Switch project references to NuGet references")]
     public class SwitchProjectsToPackagesCommand : CommandBase
     {
+        private const string SolutionFolderTypeGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+
+        private static readonly Regex ProjectLineRegex = new Regex(
+            @"^Project\(""(?<typeGuid>[^""]+)""\)\s*=\s*""(?<name>[^""]+)"",\s*""(?<path>[^""]+)"",\s*""(?<projectGuid>[^""]+)""",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex NestedProjectRegex = new Regex(
+            @"^\s*\{(?<child>[A-F0-9\-]+)\}\s*=\s*\{(?<parent>[A-F0-9\-]+)\}\s*$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         [Argument(Position = 1, IsRequired = false, Description = "Configuration .json file")]
         public string Configuration { get; set; } = "switcher.json";
 
@@ -111,6 +124,7 @@ namespace Dnt.Commands.Packages
             try
             {
                 var solution = await serializer.OpenAsync(configuration.ActualSolution, CancellationToken.None);
+                CaptureSolutionProjectFolders(configuration);
                 var projects = new List<string>();
                 foreach (var mapping in configuration.Mappings)
                 {
@@ -136,6 +150,220 @@ namespace Dnt.Commands.Packages
             {
                 host.WriteError("Solution " + configuration.ActualSolution + " could not be loaded. " + ex.Message);
             }
+        }
+
+        private static void CaptureSolutionProjectFolders(ReferenceSwitcherConfiguration configuration)
+        {
+            var solutionFolderMap = LoadSolutionFolderMap(configuration.ActualSolution);
+            if (solutionFolderMap.Count == 0)
+            {
+                return;
+            }
+
+            if (configuration.SolutionProjectFolders == null)
+            {
+                configuration.SolutionProjectFolders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            foreach (var mapping in configuration.Mappings)
+            {
+                foreach (var path in mapping.Value)
+                {
+                    var actualPath = configuration.GetActualPath(path);
+                    if (solutionFolderMap.TryGetValue(actualPath, out var folder))
+                    {
+                        configuration.SolutionProjectFolders[actualPath] = folder;
+                    }
+                }
+            }
+        }
+
+        private static Dictionary<string, string> LoadSolutionFolderMap(string solutionPath)
+        {
+            if (solutionPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+            {
+                return LoadSolutionFolderMapFromSlnx(solutionPath);
+            }
+
+            if (solutionPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                return LoadSolutionFolderMapFromSln(solutionPath);
+            }
+
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static Dictionary<string, string> LoadSolutionFolderMapFromSlnx(string solutionPath)
+        {
+            var solutionDir = Path.GetDirectoryName(solutionPath);
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            XDocument document;
+            try
+            {
+                document = XDocument.Load(solutionPath);
+            }
+            catch
+            {
+                return result;
+            }
+
+            var folderElements = document.Descendants().Where(e => e.Name.LocalName == "Folder");
+            foreach (var folderElement in folderElements)
+            {
+                var fullFolderPath = GetFullFolderPath(folderElement);
+                var normalizedFolder = NormalizeSolutionFolderName(fullFolderPath);
+                if (string.IsNullOrWhiteSpace(normalizedFolder))
+                {
+                    continue;
+                }
+
+                var projectElements = folderElement.Elements().Where(e => e.Name.LocalName == "Project");
+                foreach (var projectElement in projectElements)
+                {
+                    var projectPath = projectElement.Attribute("Path")?.Value;
+                    if (string.IsNullOrWhiteSpace(projectPath))
+                    {
+                        continue;
+                    }
+
+                    var absolutePath = PathUtilities.ToAbsolutePath(projectPath, solutionDir);
+                    result[absolutePath] = normalizedFolder;
+                }
+            }
+
+            return result;
+        }
+
+        private static Dictionary<string, string> LoadSolutionFolderMapFromSln(string solutionPath)
+        {
+            var solutionDir = Path.GetDirectoryName(solutionPath);
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var folderGuidToName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var projectGuidToPath = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var nestedProjects = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            string[] lines;
+            try
+            {
+                lines = File.ReadAllLines(solutionPath);
+            }
+            catch
+            {
+                return result;
+            }
+
+            var inNestedProjects = false;
+            foreach (var line in lines)
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("Project(", StringComparison.OrdinalIgnoreCase))
+                {
+                    var match = ProjectLineRegex.Match(trimmed);
+                    if (match.Success)
+                    {
+                        var typeGuid = match.Groups["typeGuid"].Value;
+                        var name = match.Groups["name"].Value;
+                        var path = match.Groups["path"].Value;
+                        var projectGuid = match.Groups["projectGuid"].Value.Trim('{', '}');
+
+                        if (string.Equals(typeGuid, SolutionFolderTypeGuid, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var normalized = NormalizeSolutionFolderName(name);
+                            if (!string.IsNullOrWhiteSpace(normalized))
+                            {
+                                folderGuidToName[projectGuid] = normalized;
+                            }
+                        }
+                        else if (!string.IsNullOrWhiteSpace(path))
+                        {
+                            projectGuidToPath[projectGuid] = path;
+                        }
+                    }
+                }
+                else if (trimmed.StartsWith("GlobalSection(NestedProjects)", StringComparison.OrdinalIgnoreCase))
+                {
+                    inNestedProjects = true;
+                }
+                else if (inNestedProjects)
+                {
+                    if (trimmed.StartsWith("EndGlobalSection", StringComparison.OrdinalIgnoreCase))
+                    {
+                        inNestedProjects = false;
+                    }
+                    else
+                    {
+                        var match = NestedProjectRegex.Match(trimmed);
+                        if (match.Success)
+                        {
+                            nestedProjects[match.Groups["child"].Value] = match.Groups["parent"].Value;
+                        }
+                    }
+                }
+            }
+
+            foreach (var projectEntry in projectGuidToPath)
+            {
+                var folderPath = BuildFolderPath(projectEntry.Key, nestedProjects, folderGuidToName);
+                if (!string.IsNullOrWhiteSpace(folderPath))
+                {
+                    var absolutePath = PathUtilities.ToAbsolutePath(projectEntry.Value, solutionDir);
+                    result[absolutePath] = folderPath;
+                }
+            }
+
+            return result;
+        }
+
+        private static string BuildFolderPath(
+            string projectGuid,
+            Dictionary<string, string> nestedProjects,
+            Dictionary<string, string> folderGuidToName)
+        {
+            if (!nestedProjects.TryGetValue(projectGuid, out var currentGuid))
+                return null;
+
+            var segments = new List<string>();
+            while (folderGuidToName.TryGetValue(currentGuid, out var folderName))
+            {
+                segments.Add(folderName);
+                if (!nestedProjects.TryGetValue(currentGuid, out currentGuid))
+                    break;
+            }
+
+            if (segments.Count == 0)
+                return null;
+
+            segments.Reverse();
+            return NormalizeSolutionFolderName(string.Join(Path.DirectorySeparatorChar.ToString(), segments));
+        }
+
+        private static string NormalizeSolutionFolderName(string folderName)
+        {
+            if (string.IsNullOrWhiteSpace(folderName))
+                return null;
+
+            var parts = folderName.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length > 0 ? string.Join(Path.DirectorySeparatorChar.ToString(), parts) : null;
+        }
+
+        private static string GetFullFolderPath(XElement folderElement)
+        {
+            var segments = new List<string>();
+            var current = folderElement;
+
+            while (current != null && current.Name.LocalName == "Folder")
+            {
+                var name = current.Attribute("Name")?.Value;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    segments.Add(name);
+                }
+                current = current.Parent;
+            }
+
+            segments.Reverse();
+            return string.Join(Path.DirectorySeparatorChar.ToString(), segments);
         }
 
         private static IReadOnlyList<(string ProjectPath, string PackageVersion)> SwitchToPackage(

--- a/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
+++ b/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
@@ -25,6 +25,9 @@ namespace Dnt.Commands.Packages.Switcher
         [JsonProperty("restore", NullValueHandling = NullValueHandling.Ignore)]
         public List<RestoreProjectInformation> Restore { get; set; } = new List<RestoreProjectInformation>();
 
+        [JsonProperty("solutionProjectFolders", NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, string> SolutionProjectFolders { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         [JsonIgnore]
         public string ActualSolution => PathUtilities.ToAbsolutePath(Solution, System.IO.Path.GetDirectoryName(Path));
 
@@ -34,6 +37,29 @@ namespace Dnt.Commands.Packages.Switcher
         public string GetActualPath(string path)
         {
             return PathUtilities.ToAbsolutePath(path, System.IO.Path.GetDirectoryName(Path));
+        }
+
+        public string GetSolutionFolderForProject(string projectPath)
+        {
+            if (SolutionProjectFolders == null || SolutionProjectFolders.Count == 0)
+            {
+                return null;
+            }
+
+            var absoluteProjectPath = System.IO.Path.GetFullPath(projectPath);
+            if (SolutionProjectFolders.TryGetValue(absoluteProjectPath, out var folder))
+            {
+                return folder;
+            }
+
+            var solutionDir = System.IO.Path.GetDirectoryName(ActualSolution);
+            var relativePath = PathUtilities.ToRelativePath(absoluteProjectPath, solutionDir);
+            if (SolutionProjectFolders.TryGetValue(relativePath, out folder))
+            {
+                return folder;
+            }
+
+            return null;
         }
 
         public static ReferenceSwitcherConfiguration Load(string fileName, IConsoleHost host)


### PR DESCRIPTION
Preserves original solution folder placement when switching between
package and project references, so re-added projects are restored to
their original folders instead of the solution root.

Supports classic .sln files (including .NET Core 9 and lower) and the
new .snlx format, while avoiding changes to existing .slnx behaviour
and skipping unsupported solution formats.

Adds folder-capture logic to both switch-to-packages and
switch-to-projects paths via CaptureSolutionProjectFolders and
LoadSolutionFolderMap, capturing folder mappings before removal and
restore.

Implements LoadSolutionFolderMapFromSln using SolutionFile.Parse
(Microsoft.Build.Construction) to enumerate solution folders, build
nested folder paths, and map project absolute paths to folder paths.

Persists captured mappings in configuration via a new
solutionProjectFolders JSON property and adds
GetSolutionFolderForProject to resolve folders by absolute or relative
project path.

Re-adds projects grouped by target solution folder and invokes
`dotnet sln add` once per group with --solution-folder to restore
original placement. Folder names are normalised via
NormalizeSolutionFolderName.