### PR TITLE
Fix NuGet package validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ DNT (DotNetTools) is a .NET CLI tool for managing .NET Core, Standard, and SDK-s
 
 ## Git Rules
 
-- Never include "Claude" or "Co-Authored-By" lines in commit messages or git history.
+- Never include "Claude", "Co-Authored-By", or AI attribution in commit messages, PR descriptions, or GitHub comments.
 
 ## Build Commands
 

--- a/src/Dnt.Commands/Dnt.Commands.csproj
+++ b/src/Dnt.Commands/Dnt.Commands.csproj
@@ -9,7 +9,11 @@
 		<PackageId>DNT.Commands</PackageId>
 		<Description>Command line tools to manage .NET Core, Standard and SDK-style projects and solutions.</Description>
 		<PackageProjectUrl>https://github.com/RSuter/DNT</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/RicoSuter/DNT</RepositoryUrl>
+		<PackageTags>dotnet;tools;nuget;projects;solutions</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Fluid.Core" Version="2.31.0" />

--- a/src/Dnt/Dnt.csproj
+++ b/src/Dnt/Dnt.csproj
@@ -15,6 +15,8 @@
 		<ToolCommandName>dnt</ToolCommandName>
 		<Description>Command line tools to manage .NET Core, Standard and SDK-style projects and solutions.</Description>
 		<PackageProjectUrl>https://github.com/RSuter/DNT</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/RicoSuter/DNT</RepositoryUrl>
+		<PackageTags>dotnet;tools;nuget;projects;solutions</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net8.0'">


### PR DESCRIPTION
## Summary
- Add `RepositoryUrl` and `PackageTags` to `Dnt.csproj` and `Dnt.Commands.csproj`
- Enable XML documentation generation for `Dnt.Commands`
- Update CLAUDE.md git rules

Fixes the validation failure in the v3.1.0 release workflow.