### PR TITLE
Switch NPM deploy to trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Extract version from tag
@@ -151,8 +151,6 @@ jobs:
 
       - name: Set version and publish
         working-directory: src/Dnt.Npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
           npm publish --provenance

--- a/src/Dnt.Commands/Dnt.Commands.csproj
+++ b/src/Dnt.Commands/Dnt.Commands.csproj
@@ -8,7 +8,7 @@
 		<Company>Rico Suter</Company>
 		<PackageId>DNT.Commands</PackageId>
 		<Description>Command line tools to manage .NET Core, Standard and SDK-style projects and solutions.</Description>
-		<PackageProjectUrl>https://github.com/RSuter/DNT</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/RicoSuter/DNT</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/RicoSuter/DNT</RepositoryUrl>
 		<PackageTags>dotnet;tools;nuget;projects;solutions</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Dnt.NetFx/Dnt.NetFx.csproj
+++ b/src/Dnt.NetFx/Dnt.NetFx.csproj
@@ -7,7 +7,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <IsPackable>false</IsPackable>
     <Description>Command line tools to manage .NET Core, Standard and SDK-style projects and solutions.</Description>
-    <PackageProjectUrl>https://github.com/RSuter/DNT</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/RicoSuter/DNT</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dnt.Npm/README.md
+++ b/src/Dnt.Npm/README.md
@@ -1,3 +1,3 @@
 Dnt.Npm
 
-https://github.com/RSuter/DNT
+https://github.com/RicoSuter/DNT

--- a/src/Dnt.Npm/package.json
+++ b/src/Dnt.Npm/package.json
@@ -4,7 +4,7 @@
   "optionalDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RSuter/DNT.git"
+    "url": "git+https://github.com/RicoSuter/DNT.git"
   },
   "scripts": {},
   "author": {
@@ -16,14 +16,14 @@
     "dnt": "bin/dnt.js"
   },
   "bugs": {
-    "url": "https://github.com/RSuter/DNT/issues"
+    "url": "https://github.com/RicoSuter/DNT/issues"
   },
   "engines": {
     "npm": ">=3.10.8"
   },
   "description": "DNT (DotNetTools).",
   "directories": {},
-  "homepage": "https://github.com/RSuter/DNT",
+  "homepage": "https://github.com/RicoSuter/DNT",
   "installable": true,
   "keywords": [
     "dnt",

--- a/src/Dnt/Dnt.csproj
+++ b/src/Dnt/Dnt.csproj
@@ -14,7 +14,7 @@
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>dnt</ToolCommandName>
 		<Description>Command line tools to manage .NET Core, Standard and SDK-style projects and solutions.</Description>
-		<PackageProjectUrl>https://github.com/RSuter/DNT</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/RicoSuter/DNT</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/RicoSuter/DNT</RepositoryUrl>
 		<PackageTags>dotnet;tools;nuget;projects;solutions</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` secret dependency, use OIDC trusted publishing instead
- Bump Node.js from 20 to 22 (required for trusted publishing)

## Setup required
Before merging, configure trusted publishing on npmjs.com:
1. Go to https://www.npmjs.com/package/dotnettools > Settings > Trusted Publishers
2. Add GitHub Actions: owner `RicoSuter`, repo `DNT`, workflow `build.yml`

After confirming it works, the `NPM_TOKEN` secret can be removed from repo settings.