### PR TITLE
Fix NPM trusted publishing OIDC auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Summary
Remove `registry-url` from `setup-node` action. When `registry-url` is set, `setup-node` creates an `.npmrc` that expects a `NODE_AUTH_TOKEN` env var, which overrides OIDC authentication. Without it, npm uses OIDC from the `id-token: write` permission directly.