### PR TITLE
Fix NPM trusted publishing: upgrade npm for OIDC support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Extract version from tag
         id: version
         run: |


### PR DESCRIPTION
## Summary
Node 22 ships with npm 10.x, but trusted publishing requires npm >= 11.5.1. Added `npm install -g npm@latest` before publish.