### PR TITLE
Fix NPM trusted publishing: use Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,10 +140,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+          node-version: 24
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Summary
Use Node 24 instead of Node 22 + npm upgrade. Node 24 ships with npm 11.5+ which supports OIDC trusted publishing natively. The previous `npm install -g npm@latest` approach crashed with `MODULE_NOT_FOUND`.