### PR TITLE
Add path variables and git-worktree overrides to the reference switcherSwitcher worktree variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,6 @@ paket-files/
 __pycache__/
 *.pyc
 /Dnt/Properties/launchSettings.json
+
+# DNT reference-switcher local overrides (developer worktree targets)
+*.local.json

--- a/README.md
+++ b/README.md
@@ -213,6 +213,59 @@ Now all NJsonSchema, or UA-.NETStandard, package references in the NSwag, or MyO
 
 - removeProjects: (Default: true) Removes mapped projects from the solution and ignores mapped projects when using switch-to-packages.
 
+#### Path variables and git worktrees
+
+Instead of hard-coding the full relative path in every mapping, you can define a `variables` block once and reference it from mappings with MSBuild-style `$(name)` tokens. Changing one variable re-points every mapping — handy when the referenced libraries live in a shared parent folder you want to swap out, for example a different git worktree of the library:
+
+```json
+{
+  "solution": "NSwag.sln",
+  "variables": {
+    "NJsonSchema": "../../NJsonSchema"
+  },
+  "mappings": {
+    "NJsonSchema": "$(NJsonSchema)/src/NJsonSchema/NJsonSchema.csproj",
+    "NJsonSchema.CodeGeneration": "$(NJsonSchema)/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj"
+  }
+}
+```
+
+Variables may reference other variables (e.g. `"root": "../.."`, `"NJsonSchema": "$(root)/NJsonSchema"`) and may be used in `solution` as well. Tokens must appear only in the directory portions of a path, not the file name. An undefined `$(name)` is an error.
+
+##### Overriding variables without editing the committed file
+
+When working with git worktrees you usually want to point the switcher at a *different* checkout of a library without editing (and risking committing) the shared `switcher.json`. Variable values can be overridden from several layers, applied in increasing order of precedence:
+
+1. Committed `variables` in `switcher.json` (the defaults).
+2. A local override file `switcher.local.json` next to the config (or a path passed with `/profile:`). Add `*.local.json` to `.gitignore` so it stays out of version control. It only needs a `variables` block:
+
+   ```json
+   { "variables": { "NJsonSchema": "../../NJsonSchema-featureX" } }
+   ```
+
+3. Environment variables named `DNT_SWITCHER_VAR_<NAME>`, e.g. `DNT_SWITCHER_VAR_NJSONSCHEMA=../../NJsonSchema-featureX`.
+4. The `/variables:` command-line option (highest precedence), a semicolon-delimited list — quote the whole value. Because the configuration file is a positional argument, specify it explicitly on the command line when using `/variables:`:
+
+   ```
+   dnt switch-to-projects switcher.json /variables:"NJsonSchema=../../NJsonSchema-featureX"
+   ```
+
+Run with `--verbose` (or whenever an override is active) to print the effective variables and where each one came from. Overrides never modify your committed `variables` block. When an override is active, `switch-to-projects` records the effective values in a transient `restoreVariables` section so `switch-to-packages` can restore against the same paths; `switch-to-packages` removes that section again (see below). With no override active, nothing is written back. For a hands-free, per-worktree setup the local `switcher.local.json` file is usually the most convenient layer.
+
+A typical worktree workflow:
+
+```
+# in the library repo, create a worktree for the branch you want to develop against
+git worktree add ../NJsonSchema-featureX featureX
+
+# in the consuming repo, point the switcher at that worktree (no committed change)
+dnt switch-to-projects switcher.json /variables:"NJsonSchema=../../NJsonSchema-featureX"
+# ... work across both repos in one solution ...
+dnt switch-to-packages
+```
+
+`switch-to-projects` records the variable values it used, so `switch-to-packages` restores the same references even if you forget to pass the same override — it warns when the current values differ and uses the recorded ones.
+
 ### switch-to-packages
 
 After implementing and testing, switch back to NuGet references and update to the latest version: 

--- a/src/Dnt.Commands/Dnt.Commands.csproj
+++ b/src/Dnt.Commands/Dnt.Commands.csproj
@@ -16,6 +16,9 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
+		<InternalsVisibleTo Include="Dnt.Tests" />
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Fluid.Core" Version="2.31.0" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.1" />
 		<PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />

--- a/src/Dnt.Commands/Packages/SwitchCommandBase.cs
+++ b/src/Dnt.Commands/Packages/SwitchCommandBase.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dnt.Commands.Packages.Switcher;
+using NConsole;
+using Newtonsoft.Json;
+
+namespace Dnt.Commands.Packages
+{
+    /// <summary>Shared base for the reference-switcher commands. Hosts the common arguments and the layered
+    /// variable-override loading so both directions resolve paths identically.</summary>
+    public abstract class SwitchCommandBase : CommandBase
+    {
+        [Argument(Position = 1, IsRequired = false, Description = "Configuration .json file")]
+        public string Configuration { get; set; } = "switcher.json";
+
+        [Argument(Name = "variables", IsRequired = false,
+            Description = "Override switcher variables (semicolon-delimited), e.g. /variables:\"NConsole=../../NConsole;Foo=../Foo\". Specify the config file explicitly when using this. Highest precedence.")]
+        public string VariableOverrides { get; set; }
+
+        [Argument(Name = "profile", IsRequired = false,
+            Description = "Path to a local override file (defaults to <config>.local.json next to the config), e.g. /profile:switcher.wt.json.")]
+        public string Profile { get; set; }
+
+        /// <summary>Loads the configuration and applies the layered variable overrides
+        /// (committed &lt; local file &lt; environment &lt; command line).</summary>
+        protected ReferenceSwitcherConfiguration LoadConfiguration(IConsoleHost host)
+        {
+            var configuration = ReferenceSwitcherConfiguration.Load(Configuration, host);
+            if (configuration == null)
+            {
+                return null;
+            }
+
+            var localFilePath = GetLocalOverridePath(configuration);
+            var localVariables = LoadLocalFileVariables(localFilePath, host);
+            var environmentVariables = VariableOverrideParser.FromEnvironment();
+            var commandLineVariables = VariableOverrideParser.Parse(VariableOverrides);
+
+            configuration.ApplyVariableOverrides(localVariables, environmentVariables, commandLineVariables);
+
+            ReportEffectiveVariables(host, configuration, localFilePath, localVariables, environmentVariables, commandLineVariables);
+
+            return configuration;
+        }
+
+        /// <summary>Returns a plain-dictionary copy of the effective variables to record for restore, or null when no
+        /// override is active (the effective set equals the committed <c>variables</c>). Returning null keeps the shared
+        /// <c>switcher.json</c> free of a redundant <c>restoreVariables</c> section in the common, no-override case, so
+        /// override-only paths are written back only when an override is actually in play.</summary>
+        protected static Dictionary<string, string> SnapshotEffectiveVariables(ReferenceSwitcherConfiguration configuration)
+        {
+            var effective = configuration.EffectiveVariables;
+            if (effective == null || effective.Count == 0)
+            {
+                return null;
+            }
+
+            if (!DiffersFromCommitted(effective, configuration.Variables))
+            {
+                return null;
+            }
+
+            return effective.ToDictionary(entry => entry.Key, entry => entry.Value);
+        }
+
+        private static bool DiffersFromCommitted(
+            IReadOnlyDictionary<string, string> effective, IReadOnlyDictionary<string, string> committed)
+        {
+            committed = committed ?? new Dictionary<string, string>();
+            if (effective.Count != committed.Count)
+            {
+                return true;
+            }
+
+            foreach (var entry in effective)
+            {
+                if (!committed.TryGetValue(entry.Key, out var committedValue) ||
+                    !string.Equals(committedValue, entry.Value, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private string GetLocalOverridePath(ReferenceSwitcherConfiguration configuration)
+        {
+            var directory = Path.GetDirectoryName(configuration.Path);
+
+            if (!string.IsNullOrWhiteSpace(Profile))
+            {
+                // Resolve a relative profile against the config directory (like the default below), not the process CWD,
+                // so `/profile:switcher.wt.json` finds the file next to the config regardless of where dnt is run from.
+                return Path.IsPathRooted(Profile) ? Profile : Path.Combine(directory ?? string.Empty, Profile);
+            }
+
+            var name = Path.GetFileNameWithoutExtension(configuration.Path);
+            var extension = Path.GetExtension(configuration.Path);
+            return Path.Combine(directory ?? string.Empty, name + ".local" + extension);
+        }
+
+        private static Dictionary<string, string> LoadLocalFileVariables(string path, IConsoleHost host)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return null;
+            }
+
+            try
+            {
+                var file = JsonConvert.DeserializeObject<LocalOverrideFile>(File.ReadAllText(path));
+                if (file?.Variables == null)
+                {
+                    return null;
+                }
+
+                // Match casing insensitively so a differently-cased local-file key is attributed and applied correctly.
+                return new Dictionary<string, string>(file.Variables, StringComparer.OrdinalIgnoreCase);
+            }
+            catch (JsonException e)
+            {
+                host.WriteError($"Local override file '{path}' could not be loaded: {e.Message}");
+                return null;
+            }
+        }
+
+        private void ReportEffectiveVariables(IConsoleHost host, ReferenceSwitcherConfiguration configuration,
+            string localFilePath, Dictionary<string, string> localVariables,
+            Dictionary<string, string> environmentVariables, Dictionary<string, string> commandLineVariables)
+        {
+            var effective = configuration.EffectiveVariables;
+            if (effective == null || effective.Count == 0)
+            {
+                return;
+            }
+
+            var overrideActive =
+                (localVariables != null && localVariables.Count > 0) ||
+                (environmentVariables != null && environmentVariables.Count > 0) ||
+                (commandLineVariables != null && commandLineVariables.Count > 0);
+
+            // Only chatter when an override layer is in play or the user asked for verbose output.
+            if (!overrideActive && !Verbose)
+            {
+                return;
+            }
+
+            var localFileName = string.IsNullOrEmpty(localFilePath) ? "local file" : Path.GetFileName(localFilePath);
+
+            host.WriteMessage("Effective switcher variables:\n");
+            foreach (var entry in effective.OrderBy(e => e.Key))
+            {
+                string source;
+                if (commandLineVariables != null && commandLineVariables.ContainsKey(entry.Key))
+                    source = "/variables:";
+                else if (environmentVariables != null && environmentVariables.ContainsKey(entry.Key))
+                    source = VariableOverrideParser.EnvironmentVariablePrefix + entry.Key;
+                else if (localVariables != null && localVariables.ContainsKey(entry.Key))
+                    source = localFileName;
+                else
+                    source = Path.GetFileName(configuration.Path);
+
+                host.WriteMessage($"    {entry.Key} = {entry.Value}   (source: {source})\n");
+            }
+        }
+
+        private class LocalOverrideFile
+        {
+            [JsonProperty("variables")]
+            public Dictionary<string, string> Variables { get; set; }
+        }
+    }
+}

--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -14,14 +14,11 @@ using NConsole;
 namespace Dnt.Commands.Packages
 {
     [Command(Name = "switch-to-projects", Description = "Switch NuGet references to project references")]
-    public class SwitchPackagesToProjectsCommand : CommandBase
+    public class SwitchPackagesToProjectsCommand : SwitchCommandBase
     {
-        [Argument(Position = 1, IsRequired = false, Description = "Configuration .json file")]
-        public string Configuration { get; set; } = "switcher.json";
-
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
-            var configuration = ReferenceSwitcherConfiguration.Load(Configuration, host);
+            var configuration = LoadConfiguration(host);
             if (configuration == null)
             {
                 return null;
@@ -29,6 +26,9 @@ namespace Dnt.Commands.Packages
 
             await AddProjectsToSolutionAsync(configuration, host);
             await SwitchToProjectsAsync(configuration, host);
+
+            // Record the effective variables used so switch-to-packages can restore the exact same references.
+            configuration.RestoreVariables = SnapshotEffectiveVariables(configuration);
 
             configuration.Save();
 

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -14,18 +14,17 @@ using NConsole;
 namespace Dnt.Commands.Packages
 {
     [Command(Name = "switch-to-packages", Description = "Switch project references to NuGet references")]
-    public class SwitchProjectsToPackagesCommand : CommandBase
+    public class SwitchProjectsToPackagesCommand : SwitchCommandBase
     {
-        [Argument(Position = 1, IsRequired = false, Description = "Configuration .json file")]
-        public string Configuration { get; set; } = "switcher.json";
-
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
-            var configuration = ReferenceSwitcherConfiguration.Load(Configuration, host);
+            var configuration = LoadConfiguration(host);
             if (configuration == null)
             {
                 return null;
             }
+
+            ReconcileRestoreVariables(configuration, host);
 
             await SwitchToPackagesAsync(host, configuration);
 
@@ -35,9 +34,48 @@ namespace Dnt.Commands.Packages
             }
 
             configuration.Restore = null; // restore information no longer needed
+            configuration.RestoreVariables = null; // transient switch snapshot no longer needed
             configuration.Save();
 
             return null;
+        }
+
+        /// <summary>If switch-to-projects recorded a different set of variables than the current run resolves,
+        /// warns and re-applies the recorded snapshot so references restore against the paths that were written.</summary>
+        private static void ReconcileRestoreVariables(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
+        {
+            var recorded = configuration.RestoreVariables;
+            if (recorded == null || recorded.Count == 0)
+            {
+                return;
+            }
+
+            var current = configuration.EffectiveVariables ?? new Dictionary<string, string>();
+            var differing = new List<string>();
+            foreach (var entry in recorded)
+            {
+                current.TryGetValue(entry.Key, out var currentValue);
+                if (!string.Equals(currentValue, entry.Value, StringComparison.Ordinal))
+                {
+                    differing.Add(entry.Key);
+                }
+            }
+
+            if (differing.Count == 0)
+            {
+                return;
+            }
+
+            host.WriteMessage("Warning: switch-to-packages is running with different switcher variables than switch-to-projects used.\n");
+            foreach (var key in differing)
+            {
+                recorded.TryGetValue(key, out var recordedValue);
+                current.TryGetValue(key, out var currentValue);
+                host.WriteMessage($"    {key}: switched in with '{recordedValue}', now '{currentValue ?? "(unset)"}'. Using '{recordedValue}' to restore.\n");
+            }
+
+            // Re-apply the recorded snapshot so reference matching targets exactly what switch-to-projects wrote.
+            configuration.ApplyVariableOverrides(recorded);
         }
 
         private static async Task SwitchToPackagesAsync(IConsoleHost host, ReferenceSwitcherConfiguration configuration)
@@ -56,7 +94,7 @@ namespace Dnt.Commands.Packages
                 var globalProperties = ProjectExtensions.GetGlobalProperties(Path.GetFullPath(configuration.ActualSolution));
                 var mappedProjectFilePaths = configuration.Mappings.Values
                     .SelectMany(x => x)
-                    .Select(p => Path.GetFileName(p))
+                    .Select(p => Path.GetFileName(configuration.GetActualPath(p)))
                     .ToList();
                 foreach (var solutionProject in solution.SolutionProjects)
                 {

--- a/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
+++ b/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using Dnt.Commands.Infrastructure;
 using NConsole;
 using Newtonsoft.Json;
@@ -9,6 +10,8 @@ namespace Dnt.Commands.Packages.Switcher
 {
     public class ReferenceSwitcherConfiguration
     {
+        private static readonly Regex VariableTokenRegex = new Regex(@"\$\(([A-Za-z0-9_.\-]+)\)", RegexOptions.Compiled);
+
         [JsonIgnore]
         internal string Path { get; set; }
 
@@ -18,6 +21,9 @@ namespace Dnt.Commands.Packages.Switcher
         [JsonProperty("solutionFolder")]
         public string SolutionFolder { get; set; }
 
+        [JsonProperty("variables", NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, string> Variables { get; set; }
+
         [JsonProperty("mappings", Required = Required.Always)]
         [JsonConverter(typeof(SingleOrArrayConverter))]
         public Dictionary<string, List<string>> Mappings { get; set; }
@@ -25,15 +31,75 @@ namespace Dnt.Commands.Packages.Switcher
         [JsonProperty("restore", NullValueHandling = NullValueHandling.Ignore)]
         public List<RestoreProjectInformation> Restore { get; set; } = new List<RestoreProjectInformation>();
 
+        [JsonProperty("restoreVariables", NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, string> RestoreVariables { get; set; }
+
         [JsonIgnore]
-        public string ActualSolution => PathUtilities.ToAbsolutePath(Solution, System.IO.Path.GetDirectoryName(Path));
+        public IReadOnlyDictionary<string, string> EffectiveVariables { get; private set; }
+
+        [JsonIgnore]
+        public string ActualSolution => PathUtilities.ToAbsolutePath(ExpandVariables(Solution), System.IO.Path.GetDirectoryName(Path));
 
         [JsonProperty("removeProjects", NullValueHandling = NullValueHandling.Ignore)]
         public bool RemoveProjects { get; set; } = true;
 
         public string GetActualPath(string path)
         {
-            return PathUtilities.ToAbsolutePath(path, System.IO.Path.GetDirectoryName(Path));
+            return PathUtilities.ToAbsolutePath(ExpandVariables(path), System.IO.Path.GetDirectoryName(Path));
+        }
+
+        /// <summary>Gets the variable set used for expansion (layered overrides if applied, otherwise the committed variables).</summary>
+        private IReadOnlyDictionary<string, string> Vars => EffectiveVariables ?? Variables;
+
+        /// <summary>Layers variable overrides on top of the committed <see cref="Variables"/> (lowest to highest precedence).
+        /// Overrides only affect in-memory path expansion and are never persisted by <see cref="Save"/>.</summary>
+        public void ApplyVariableOverrides(params IReadOnlyDictionary<string, string>[] layersLowToHigh)
+        {
+            // Case-insensitive so an environment override such as DNT_SWITCHER_VAR_NJSONSCHEMA (env var names are
+            // conventionally upper-cased) still overrides a committed variable named "NJsonSchema", and so $(NJsonSchema)
+            // resolves regardless of the casing the override layer used.
+            var effective = new Dictionary<string, string>(
+                Variables ?? new Dictionary<string, string>(), StringComparer.OrdinalIgnoreCase);
+            if (layersLowToHigh != null)
+            {
+                foreach (var layer in layersLowToHigh)
+                {
+                    if (layer == null)
+                        continue;
+
+                    foreach (var entry in layer)
+                        effective[entry.Key] = entry.Value;
+                }
+            }
+
+            EffectiveVariables = effective;
+        }
+
+        /// <summary>Expands MSBuild-style <c>$(name)</c> tokens using the effective variables. Tokens must appear only in
+        /// directory portions of a path. Undefined variables and cyclic references throw <see cref="ArgumentException"/>.</summary>
+        internal string ExpandVariables(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value;
+
+            return VariableTokenRegex.Replace(value, match => ResolveVariable(match.Groups[1].Value, null));
+        }
+
+        private string ResolveVariable(string name, HashSet<string> resolving)
+        {
+            if (Vars == null || !Vars.TryGetValue(name, out var raw))
+                throw new ArgumentException($"Undefined switcher variable '$({name})'.");
+
+            // Track the chain of variables currently being resolved so a genuine cycle is caught by identity,
+            // rather than rejecting legitimate deep (but acyclic) aliasing with a fixed depth cap.
+            resolving = resolving ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!resolving.Add(name))
+                throw new ArgumentException($"Cyclic switcher variable reference at '$({name})'.");
+
+            var result = VariableTokenRegex.Replace(raw, match => ResolveVariable(match.Groups[1].Value, resolving));
+
+            resolving.Remove(name);
+            return result;
         }
 
         public static ReferenceSwitcherConfiguration Load(string fileName, IConsoleHost host)

--- a/src/Dnt.Commands/Packages/Switcher/VariableOverrideParser.cs
+++ b/src/Dnt.Commands/Packages/Switcher/VariableOverrideParser.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Dnt.Commands.Packages.Switcher
+{
+    /// <summary>Parses switcher variable overrides from the command line and environment variables.</summary>
+    public static class VariableOverrideParser
+    {
+        public const string EnvironmentVariablePrefix = "DNT_SWITCHER_VAR_";
+
+        /// <summary>Parses a semicolon-delimited override spec such as <c>"A=../x;B=../y"</c>.
+        /// Entries are split on the first '=' only (values may contain '='); empty entries are ignored;
+        /// duplicate keys use the last value.</summary>
+        public static Dictionary<string, string> Parse(string spec)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(spec))
+                return result;
+
+            foreach (var entry in spec.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var separatorIndex = entry.IndexOf('=');
+                if (separatorIndex <= 0)
+                    continue;
+
+                var name = entry.Substring(0, separatorIndex).Trim();
+                var value = entry.Substring(separatorIndex + 1).Trim();
+                if (name.Length == 0)
+                    continue;
+
+                result[name] = value;
+            }
+
+            return result;
+        }
+
+        /// <summary>Reads variable overrides from environment variables named <c>DNT_SWITCHER_VAR_&lt;NAME&gt;</c>.</summary>
+        public static Dictionary<string, string> FromEnvironment(string prefix = EnvironmentVariablePrefix)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                var key = entry.Key as string;
+                if (key == null || key.Length <= prefix.Length)
+                    continue;
+
+                if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var name = key.Substring(prefix.Length);
+                if (name.Length == 0)
+                    continue;
+
+                result[name] = entry.Value as string ?? string.Empty;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Dnt.Tests/ReferenceSwitcherConfigurationTests.cs
+++ b/src/Dnt.Tests/ReferenceSwitcherConfigurationTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Dnt.Commands.Infrastructure;
+using Dnt.Commands.Packages.Switcher;
+using Xunit;
+
+namespace Dnt.Tests
+{
+    public class ReferenceSwitcherConfigurationTests
+    {
+        private static ReferenceSwitcherConfiguration CreateConfig(string configDirectory)
+        {
+            return new ReferenceSwitcherConfiguration
+            {
+                Path = Path.Combine(configDirectory, "switcher.json")
+            };
+        }
+
+        [Fact]
+        public void GetActualPath_WithVariable_ExpandsBeforeResolving()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cfgdir");
+            var config = CreateConfig(dir);
+            config.Variables = new Dictionary<string, string> { { "Lib", "../Lib" } };
+
+            var result = config.GetActualPath("$(Lib)/src/X.csproj");
+
+            Assert.Equal(PathUtilities.ToAbsolutePath("../Lib/src/X.csproj", dir), result);
+        }
+
+        [Fact]
+        public void GetActualPath_WithoutVariables_LeavesPlainPathUnchanged()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cfgdir");
+            var config = CreateConfig(dir);
+
+            var result = config.GetActualPath("../Lib/src/X.csproj");
+
+            Assert.Equal(PathUtilities.ToAbsolutePath("../Lib/src/X.csproj", dir), result);
+        }
+
+        [Fact]
+        public void ExpandVariables_UndefinedVariable_Throws()
+        {
+            var config = new ReferenceSwitcherConfiguration();
+            var ex = Assert.Throws<ArgumentException>(() => config.ExpandVariables("$(Missing)/x.csproj"));
+            Assert.Contains("Missing", ex.Message);
+        }
+
+        [Fact]
+        public void ExpandVariables_NestedVariables_Expand()
+        {
+            var config = new ReferenceSwitcherConfiguration
+            {
+                Variables = new Dictionary<string, string>
+                {
+                    { "root", "../.." },
+                    { "Lib", "$(root)/Lib" }
+                }
+            };
+
+            Assert.Equal("../../Lib/X.csproj", config.ExpandVariables("$(Lib)/X.csproj"));
+        }
+
+        [Fact]
+        public void ExpandVariables_CyclicVariables_Throw()
+        {
+            var config = new ReferenceSwitcherConfiguration
+            {
+                Variables = new Dictionary<string, string>
+                {
+                    { "a", "$(b)" },
+                    { "b", "$(a)" }
+                }
+            };
+
+            Assert.Throws<ArgumentException>(() => config.ExpandVariables("$(a)"));
+        }
+
+        [Fact]
+        public void ExpandVariables_DeepAcyclicChain_Expands()
+        {
+            const int depth = 40; // well past the old depth cap; a valid chain must not be mistaken for a cycle
+            var variables = new Dictionary<string, string>();
+            for (var i = 0; i < depth; i++)
+            {
+                variables["v" + i] = "$(v" + (i + 1) + ")";
+            }
+            variables["v" + depth] = "../leaf";
+
+            var config = new ReferenceSwitcherConfiguration { Variables = variables };
+
+            Assert.Equal("../leaf/X.csproj", config.ExpandVariables("$(v0)/X.csproj"));
+        }
+
+        [Fact]
+        public void ActualSolution_WithVariable_Expands()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "cfgdir");
+            var config = CreateConfig(dir);
+            config.Variables = new Dictionary<string, string> { { "root", ".." } };
+            config.Solution = "$(root)/App.sln";
+
+            Assert.Equal(PathUtilities.ToAbsolutePath("../App.sln", dir), config.ActualSolution);
+        }
+
+        [Fact]
+        public void ApplyVariableOverrides_LayersInPrecedenceOrder()
+        {
+            var config = new ReferenceSwitcherConfiguration
+            {
+                Variables = new Dictionary<string, string> { { "Lib", "../a" }, { "Other", "../o" } }
+            };
+
+            config.ApplyVariableOverrides(
+                new Dictionary<string, string> { { "Lib", "../b" } },                  // local file
+                new Dictionary<string, string> { { "Lib", "../c" }, { "X", "../x" } }, // environment
+                new Dictionary<string, string> { { "Lib", "../d" } });                 // command line
+
+            Assert.Equal("../d", config.EffectiveVariables["Lib"]);   // command line wins
+            Assert.Equal("../o", config.EffectiveVariables["Other"]); // committed key survives
+            Assert.Equal("../x", config.EffectiveVariables["X"]);     // environment-only key
+        }
+
+        [Fact]
+        public void Save_DoesNotPersistOverridesOrExpandedPaths()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "dnt-switcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "switcher.json");
+            try
+            {
+                File.WriteAllText(file,
+                    "{\n" +
+                    "  \"solution\": \"App.sln\",\n" +
+                    "  \"variables\": { \"Lib\": \"../Lib\" },\n" +
+                    "  \"mappings\": { \"Some.Package\": \"$(Lib)/src/Some/Some.csproj\" }\n" +
+                    "}");
+
+                var host = new TestConsoleHost();
+                var config = ReferenceSwitcherConfiguration.Load(file, host);
+                config.ApplyVariableOverrides(new Dictionary<string, string> { { "Lib", "../OVERRIDE" } });
+
+                // The override drives in-memory path resolution...
+                Assert.Contains("OVERRIDE", config.GetActualPath("$(Lib)/src/Some/Some.csproj"));
+
+                config.Save();
+
+                // ...but is never written back to disk.
+                var raw = File.ReadAllText(file);
+                Assert.Contains("$(Lib)", raw);          // templated mapping preserved
+                Assert.Contains("../Lib", raw);          // committed variable preserved
+                Assert.DoesNotContain("OVERRIDE", raw);  // override never persisted
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/src/Dnt.Tests/SwitchCommandOverrideTests.cs
+++ b/src/Dnt.Tests/SwitchCommandOverrideTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Dnt.Commands.Packages;
+using Dnt.Commands.Packages.Switcher;
+using NConsole;
+using Xunit;
+
+namespace Dnt.Tests
+{
+    public class SwitchCommandOverrideTests
+    {
+        /// <summary>Clears any ambient DNT_SWITCHER_VAR_* environment variables for the duration of a test (and
+        /// restores them afterwards) so the environment override layer read by LoadConfiguration can't leak in from
+        /// the developer's shell or CI and make the exact-value assertions non-deterministic.</summary>
+        private sealed class SwitcherEnvironmentScope : IDisposable
+        {
+            private readonly Dictionary<string, string> _saved = new Dictionary<string, string>();
+
+            public SwitcherEnvironmentScope()
+            {
+                foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                {
+                    var key = entry.Key as string;
+                    if (key != null && key.StartsWith(VariableOverrideParser.EnvironmentVariablePrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _saved[key] = entry.Value as string;
+                        Environment.SetEnvironmentVariable(key, null);
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                // Clear any DNT_SWITCHER_VAR_* set during the test, then restore the originals captured at construction.
+                foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                {
+                    var key = entry.Key as string;
+                    if (key != null && key.StartsWith(VariableOverrideParser.EnvironmentVariablePrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Environment.SetEnvironmentVariable(key, null);
+                    }
+                }
+
+                foreach (var entry in _saved)
+                {
+                    Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+                }
+            }
+        }
+
+        private class TestableToProjects : SwitchPackagesToProjectsCommand
+        {
+            public ReferenceSwitcherConfiguration Invoke(IConsoleHost host) => LoadConfiguration(host);
+            public static Dictionary<string, string> Snapshot(ReferenceSwitcherConfiguration c) => SnapshotEffectiveVariables(c);
+        }
+
+        private class TestableToPackages : SwitchProjectsToPackagesCommand
+        {
+            public ReferenceSwitcherConfiguration Invoke(IConsoleHost host) => LoadConfiguration(host);
+        }
+
+        private static string WriteConfig(string dir)
+        {
+            var file = Path.Combine(dir, "switcher.json");
+            File.WriteAllText(file,
+                "{ \"solution\": \"App.sln\", \"variables\": { \"Lib\": \"../Lib\" }, \"mappings\": { \"P\": \"$(Lib)/P.csproj\" } }");
+            return file;
+        }
+
+        [Fact]
+        public void BothCommands_ProduceIdenticalEffectiveVariables()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "dnt-switcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                using (new SwitcherEnvironmentScope())
+                {
+                    var file = WriteConfig(dir);
+                    var host = new TestConsoleHost();
+
+                    var toProjects = new TestableToProjects { Configuration = file, VariableOverrides = "Lib=../Override" };
+                    var toPackages = new TestableToPackages { Configuration = file, VariableOverrides = "Lib=../Override" };
+
+                    var a = toProjects.Invoke(host);
+                    var b = toPackages.Invoke(host);
+
+                    Assert.Equal("../Override", a.EffectiveVariables["Lib"]);
+                    Assert.Equal(a.EffectiveVariables["Lib"], b.EffectiveVariables["Lib"]);
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void LocalOverrideFile_IsDiscoveredNextToConfig_AndCliWins()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "dnt-switcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                using (new SwitcherEnvironmentScope())
+                {
+                    var file = WriteConfig(dir);
+                    File.WriteAllText(Path.Combine(dir, "switcher.local.json"),
+                        "{ \"variables\": { \"Lib\": \"../LocalLib\" } }");
+
+                    var host = new TestConsoleHost();
+
+                    // No CLI override: local file value takes effect.
+                    var localOnly = new TestableToProjects { Configuration = file }.Invoke(host);
+                    Assert.Equal("../LocalLib", localOnly.EffectiveVariables["Lib"]);
+
+                    // CLI override outranks the local file.
+                    var withCli = new TestableToProjects { Configuration = file, VariableOverrides = "Lib=../CliLib" }.Invoke(host);
+                    Assert.Equal("../CliLib", withCli.EffectiveVariables["Lib"]);
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void EnvironmentOverride_UpperCasedName_OverridesMixedCaseVariable()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "dnt-switcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                using (new SwitcherEnvironmentScope())
+                {
+                    // Committed variable is mixed-case "Lib"; the environment override uses the conventional all-caps name.
+                    var file = WriteConfig(dir);
+                    Environment.SetEnvironmentVariable(VariableOverrideParser.EnvironmentVariablePrefix + "LIB", "../EnvLib");
+
+                    var host = new TestConsoleHost();
+                    var config = new TestableToProjects { Configuration = file }.Invoke(host);
+
+                    Assert.Equal("../EnvLib", config.EffectiveVariables["Lib"]);
+                    Assert.Contains("EnvLib", config.GetActualPath("$(Lib)/P.csproj"));
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void RestoreSnapshot_OnlyRecordedWhenAnOverrideChangesAValue()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "dnt-switcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                using (new SwitcherEnvironmentScope())
+                {
+                    var file = WriteConfig(dir);
+                    var host = new TestConsoleHost();
+
+                    // No override: effective == committed, so nothing is recorded (no restoreVariables written).
+                    var plain = new TestableToProjects { Configuration = file }.Invoke(host);
+                    Assert.Null(TestableToProjects.Snapshot(plain));
+
+                    // With an override: the effective values are recorded so switch-to-packages can restore them.
+                    var overridden = new TestableToProjects { Configuration = file, VariableOverrides = "Lib=../Override" }.Invoke(host);
+                    var snapshot = TestableToProjects.Snapshot(overridden);
+                    Assert.NotNull(snapshot);
+                    Assert.Equal("../Override", snapshot["Lib"]);
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void Profile_RelativePath_ResolvedNextToConfig()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "dnt-switcher-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                using (new SwitcherEnvironmentScope())
+                {
+                    var file = WriteConfig(dir);
+                    File.WriteAllText(Path.Combine(dir, "switcher.wt.json"),
+                        "{ \"variables\": { \"Lib\": \"../ProfileLib\" } }");
+
+                    var host = new TestConsoleHost();
+
+                    // A bare relative profile name resolves next to the config, not against the process CWD.
+                    var config = new TestableToProjects { Configuration = file, Profile = "switcher.wt.json" }.Invoke(host);
+                    Assert.Equal("../ProfileLib", config.EffectiveVariables["Lib"]);
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/src/Dnt.Tests/TestConsoleHost.cs
+++ b/src/Dnt.Tests/TestConsoleHost.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using NConsole;
+
+namespace Dnt.Tests
+{
+    internal class TestConsoleHost : IConsoleHost
+    {
+        public List<string> Messages { get; } = new List<string>();
+        public List<string> Errors { get; } = new List<string>();
+
+        public void WriteMessage(string message) => Messages.Add(message);
+        public void WriteError(string message) => Errors.Add(message);
+        public string ReadValue(string message) => null;
+    }
+}

--- a/src/Dnt.Tests/VariableOverrideParserTests.cs
+++ b/src/Dnt.Tests/VariableOverrideParserTests.cs
@@ -1,0 +1,86 @@
+using System;
+using Dnt.Commands.Packages.Switcher;
+using Xunit;
+
+namespace Dnt.Tests
+{
+    public class VariableOverrideParserTests
+    {
+        [Fact]
+        public void Parse_SinglePair()
+        {
+            var result = VariableOverrideParser.Parse("Lib=../Lib");
+            Assert.Single(result);
+            Assert.Equal("../Lib", result["Lib"]);
+        }
+
+        [Fact]
+        public void Parse_MultiplePairs()
+        {
+            var result = VariableOverrideParser.Parse("A=../a;B=../b");
+            Assert.Equal(2, result.Count);
+            Assert.Equal("../a", result["A"]);
+            Assert.Equal("../b", result["B"]);
+        }
+
+        [Fact]
+        public void Parse_ValueContainingEquals_KeepsRemainder()
+        {
+            var result = VariableOverrideParser.Parse("Q=a=b=c");
+            Assert.Equal("a=b=c", result["Q"]);
+        }
+
+        [Fact]
+        public void Parse_TrimsWhitespace()
+        {
+            var result = VariableOverrideParser.Parse("  Lib = ../Lib  ");
+            Assert.Equal("../Lib", result["Lib"]);
+        }
+
+        [Fact]
+        public void Parse_IgnoresEmptyEntries()
+        {
+            var result = VariableOverrideParser.Parse(";A=../a;;");
+            Assert.Single(result);
+            Assert.Equal("../a", result["A"]);
+        }
+
+        [Fact]
+        public void Parse_DuplicateKey_LastWins()
+        {
+            var result = VariableOverrideParser.Parse("A=../a;A=../b");
+            Assert.Equal("../b", result["A"]);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Parse_NullOrEmpty_ReturnsEmpty(string spec)
+        {
+            Assert.Empty(VariableOverrideParser.Parse(spec));
+        }
+
+        [Fact]
+        public void Parse_EntryWithoutEquals_Ignored()
+        {
+            Assert.Empty(VariableOverrideParser.Parse("justtext"));
+        }
+
+        [Fact]
+        public void FromEnvironment_ReadsPrefixedVariables()
+        {
+            var prefix = "DNT_TEST_PREFIX_" + Guid.NewGuid().ToString("N") + "_";
+            try
+            {
+                Environment.SetEnvironmentVariable(prefix + "FOO", "../foo");
+                var result = VariableOverrideParser.FromEnvironment(prefix);
+                Assert.Equal("../foo", result["FOO"]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(prefix + "FOO", null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
What this does

The reference switcher lets you temporarily swap NuGet package references for local project references while you work across two repos in one solution. Mappings currently have to spell out the full relative path to each .csproj, and if the library you're referencing lives somewhere else (say, a different git worktree), you have to hand-edit the shared switcher.json which is easy to commit by accident.

This PR adds two things to make that workflow smoother:

1. Path variables. You can define a variables block once and reference it from your mappings with MSBuild-style $(name) tokens. Change one variable and every mapping re-points at once.

```
{
  "solution": "NSwag.sln",
  "variables": { "NJsonSchema": "../../NJsonSchema" },
  "mappings": {
    "NJsonSchema": "$(NJsonSchema)/src/NJsonSchema/NJsonSchema.csproj",
    "NJsonSchema.CodeGeneration": "$(NJsonSchema)/src/NJsonSchema.CodeGeneration/NJsonSchema.CodeGeneration.csproj"
  }
}
```

Variables can reference other variables, and can be used in solution too.

2. Overriding those variables without touching the committed file. This is the git-worktree case: you want to point the switcher at a different checkout of a library just for yourself, without editing (and risking committing) the shared config. Variable values can come from four layers, in increasing priority:
    
    - The committed variables block (the default).
    - A local switcher.local.json next to the config (git-ignored), or a file passed with /profile:.
    - Environment variables named DNT_SWITCHER_VAR_<NAME>.
    - The /variables:"Name=../path" command-line option (highest priority).

When an override is active, switch-to-projects records the values it used so switch-to-packages can restore the exact same references. The two switch commands now share a common base class (SwitchCommandBase) so both directions load config and resolve paths identically.
