### PR TITLE
fixes switching to projects when a .csproj in the solution is in the same folder as the solution file

### DIFF
--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -136,7 +136,8 @@ namespace Dnt.Commands.Packages
         {
             var switchedProjects = new Dictionary<string, string>();
             var project = projectInformation.Project;
-            var projectDirectory = Path.GetFullPath(Path.GetDirectoryName(solutionProject.FilePath));
+            var solutionPath = Path.GetDirectoryName(solutionProject.FilePath);
+            var projectDirectory = string.IsNullOrEmpty(solutionPath) ? Path.GetFullPath(Path.GetDirectoryName(configuration.ActualSolution)) : Path.GetFullPath(solutionPath);
 
             var centralVersioning = project.GetProperty("CentralPackagesFile") != null   // https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions
                 || project.GetPropertyValue("ManagePackageVersionsCentrally") == "true"; // https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions


### PR DESCRIPTION
I found that my previous fix resulted in all .csproj file containing just absolute links. That worked fine on Windows, but now that I'm using docker, when I try to build a docker image from a switched local solution, I get path problems (Windows paths don't translate to Linux).